### PR TITLE
Update domains.json

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -6895,7 +6895,6 @@
     "metemask.monster",
     "decentralizedwalletvalidator.online",
     "ftxskc.top",
-    "is.gd",
     "app-pancakeswap.com",
     "myetherwallet.tv",
     "pan-cakeswap.net",


### PR DESCRIPTION
From LinkSafe:
```
Hello there,

The following link is SAFE: [is.gd/Iinksafe](http://is.gd/Iinksafe)

Could [is.gd](http://is.gd/) be unblacklisted? Opera users are viewing a warning before clicking on my link
```