### PR TITLE
Please remove https://www.aulacontable.com from the blacklist

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -264,5 +264,6 @@
   "fantom.network",
   "spherefinance.store",
   "spherefinance.xyz",
-  "sphere.finance"
+  "sphere.finance",
+  "boredapeyachtclub.com"
 ]


### PR DESCRIPTION
The site http://www.aulacontable.com/ is free of phishing, please remove it from the blacklist.