### PR TITLE
Remove shoppy from blacklist

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -10745,7 +10745,6 @@
     "openseassupport.com",
     "walletdconnect.live",
     "solveddaps.live",
-    "shoppy.gg",
     "myetfervvallet.com",
     "higherrisers.com",
     "pancakeswapp-flnance.com",

--- a/blacklists/hotlist.json
+++ b/blacklists/hotlist.json
@@ -1427,7 +1427,6 @@
     "pancakeswapmeta.finance",
     "metamask.project.socjsc.com",
     "openseassupport.com",
-    "shoppy.gg",
     "realsecures.org",
     "www.mirrorcommunity.com",
     "netlifyasset.com",

--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -269,5 +269,6 @@
   "bitkubnext.exchange",
   "solanaweekly.com",
   "solanamonthly.com",
-  "walletsrecovery.org"
+  "walletsrecovery.org",
+  "shoppy.gg"
 ]


### PR DESCRIPTION
Shoppy.gg is a free eCommerce provider that allows developers/owners to sell products by creating individual shops.

#62 