### PR TITLE
Black list

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -264,5 +264,6 @@
   "fantom.network",
   "spherefinance.store",
   "spherefinance.xyz",
-  "sphere.finance"
+  "sphere.finance",
+  "boredapeyachtclub.com"
 ]


### PR DESCRIPTION
Please remove https://www.aulacontable.com from the blacklist.
This site (aulacontable.com) is free of phishing, check it again, I assure you that it is free of all threats, they are affecting our reputation, I am claiming more than 2 weeks.
Att. Webmaster
Thank you