### PR TITLE
Remove wallet.elrond.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -8421,7 +8421,6 @@
     "login.paxfulsecurity.online",
     "trrust-waillet.com",
     "wwv-kuck-oin.com",
-    "wallet.elrond.com",
     "wallet-metomask.com",
     "metamaskwallethelp.com",
     "new-myelherewullet.com",


### PR DESCRIPTION
The domain elrond.com is the official domain of the Elrond blockchain.
The website wallet.elrond.com is the web app to access and interact with your wallet online.