### PR TITLE
Remove mint.hokizukiape.com

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -20178,7 +20178,6 @@
     "xn--pensea-9wa.io",
     "pxquesst.xyz",
     "solanacraze.space",
-    "mint.hokizukiape.com",
     "databasechain-mainnet.com",
     "dapps-fix.com",
     "captchads.app",


### PR DESCRIPTION
Hi,

The domain mint.hokizukiape.com is the mint web app of the project Hokizuki Ape, a legitimate NFT collection on Polygon and Elrond blockchains ([project homepage](https://hokizukiape.com/)).
It has been unfortunately blacklisted by mistake.

Thanks in advance for your help.

Related comment from an admin of the project: https://github.com/phishfort/phishfort-lists/commit/58cc86cd8a71bc94444ca7316d84a89e0a20e49b#commitcomment-86953218
