### PR TITLE
Remove atshop.io from blacklist & hotlist.

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -24068,7 +24068,6 @@
     "rnyethereswallet.com",
     "easy-protocol.com",
     "chainpadsolution.com",
-    "atshop.io",
     "paxful-cls.com",
     "walletixapp.online",
     "paxtul-de.com",

--- a/blacklists/hotlist.json
+++ b/blacklists/hotlist.json
@@ -6136,7 +6136,6 @@
     "galaxis.bond",
     "defi-connector.com",
     "chainpadsolution.com",
-    "atshop.io",
     "jokerchaarlie.xyz",
     "mining985.co",
     "wallet.polygon.technologv.v37.icu",


### PR DESCRIPTION
ATShop.io is an ecommerce platform and does not pose any harm to its users.

Shops created on the platform do receive a domain name under `*.atshop.io`. The platform is fairly locked down and shouldn't allow a merchant to modify their shop in any way that could pose a risk of phishing.