### PR TITLE
chore: whitelist 3ac.vc

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -8548,7 +8548,6 @@
     "axieservice.org",
     "idex-ico.info",
     "walletsreconnects.com",
-    "3ac.vc",
     "www.myetherwallret.com",
     "meta-monsters.xyz",
     "connectwalletqrgenerator.online",

--- a/blacklists/hotlist.json
+++ b/blacklists/hotlist.json
@@ -2735,7 +2735,6 @@
     "www.ethecrscan.us",
     "indexval.online",
     "dxsael.app",
-    "3ac.vc",
     "meta-monsters.xyz",
     "dappsfixprotocol.site",
     "mascarastvx.blogspot.com",

--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -296,5 +296,6 @@
   "oppo.ae",
   "oppo.hk",
   "oppo.sa.com",
-  "oppo.qa"
+  "oppo.qa",
+  "3ac.vc"
 ]


### PR DESCRIPTION
# Summary 

Whitelist 3AC domain (https://3ac.vc). 3AC is a Web3 consulting firm. 

GitHub: https://github.com/3acvc
Team:
- Adam Azad (@adamazad)
- Dave Montali (@daveai)
- Federico Luzzi (@luzzif)
