### PR TITLE
Fronklab is not SCAM/PHISING!

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -296,5 +296,6 @@
   "oppo.ae",
   "oppo.hk",
   "oppo.sa.com",
-  "oppo.qa"
+  "oppo.qa",
+  "fronklab.xyz"
 ]

--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -297,5 +297,6 @@
   "oppo.hk",
   "oppo.sa.com",
   "oppo.qa",
-  "fronklab.xyz"
+  "fronklab.xyz",
+  "fronknamepass.vercel.app"
 ]


### PR DESCRIPTION
This is unfair, both sites were reported by someone I know from those who have a project/business with FRONK Token and don't like the presence of FRONKLAB. I've explained my project is not official part of them and just want to support.

fronklab. xyz is dead and now fronknamepass.vecel.app

If phishfort receives reports without filtering, this will have a bad impact on your business.

thank you