### PR TITLE
whitelist *.manifold.xyz

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -1,5 +1,6 @@
 [
   "matcha.xyz",
+  "manifold.xyz",
   "walletconnect.org",
   "walletconnect.com",
   "opensea.io",


### PR DESCRIPTION
Domain: manifold.xyz

Details: Some details about the domain (optional)
We provide minting and nft tools to independent creators.  Our primary site is manifold.xyz but we allow artists to create their own contracts, tokens, drop pages and auctions on subdomains like studio.manifold.xyz, app.manifold.xyz and so on.

Resources:
- our sites drive the vast majority of nft minting on eth, which you can verify here: https://dappradar.com/ethereum/marketplaces/manifold
- homepage manifold.xyz
- creator portal studio.manifold.xyz

Thank you.