### PR TITLE
Whitelist *.linkdrop.io

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -358,5 +358,6 @@
   "bravesoftware.com",
   "brave.com",
   "basicattentiontoken.org",
-  "axie.date"
+  "axie.date",
+  "linkdrop.io"
 ]


### PR DESCRIPTION
Domain: linkdrop.io

Details: Some details about the domain (optional)
We provide nft distribution tools to our customers such as Ledger, Zerion, Rarible and others. Some of our customers use custom claim pages we build for on a custom subdomain (Examples: zerion-claim.linkdrop.io, ethdenver.linkdrop.io)

Resources:
homepage linkdrop.io
Dashboard dashboard.lindrop.io
Twitter. https://twitter.com/linkdropHQ

Please add our domain to the whitelist as our sudomains were already blocked twice by mistake:

Zerion Claim App: https://github.com/phishfort/phishfort-lists/issues/483
EthDenver Claim App: https://github.com/phishfort/phishfort-lists/issues/176

Thank you.