### PR TITLE
Update blacklist, remove zksync-mint.summon.xyz

### DIFF
--- a/blacklists/domains.json
+++ b/blacklists/domains.json
@@ -33810,7 +33810,6 @@
     "stakeevent.com",
     "pancakesweeperingless.fun",
     "nodesync.live",
-    "zksync-mint.summon.xyz",
     "infinity.srl",
     "shibasocialclub.pro",
     "solanagift.xyz",

--- a/blacklists/hotlist.json
+++ b/blacklists/hotlist.json
@@ -3545,7 +3545,6 @@
     "csmoneyofficial.monster",
     "manage-gleendot.com",
     "idex-crypto.cn",
-    "zksync-mint.summon.xyz",
     "www.cypherwallet.cc",
     "monero-myo.site",
     "revokers.cash",


### PR DESCRIPTION
`zksync-mint.summon.xyz` domain was blocked by mistake. It's an official mint portal.

This PR will remove it from the blacklist.