### PR TITLE
ADDED - consensys-nft --> phosphor.xyz

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -584,5 +584,7 @@
   "zerion-ethdenver2023.linkdrop.io",
   "swapr.eth.limo",
   "fixedfloat.com",
-  "ff.io"
+  "ff.io",
+  "phosphor.xyz",
+  "tryphosphor.com"
 ]


### PR DESCRIPTION
Hi Team,

Consensys has rebranded Consensys-nft to Phosphor!

We are actively moving to our new domains!

Thanks!
