### PR TITLE
feat: add hyperlane.xyz to whitelisted domains

### DIFF
--- a/whitelists/domains.json
+++ b/whitelists/domains.json
@@ -661,5 +661,6 @@
   "stablecon.io",
   "makerdao.network",
   "pancakeswap.games",
-  "securechain.ai"
+  "securechain.ai",
+  "hyperlane.xyz"
 ]


### PR DESCRIPTION
Related issues:
- https://github.com/phishfort/phishfort-lists/issues/1477
- https://github.com/phishfort/phishfort-lists/issues/1476
- https://github.com/phishfort/phishfort-lists/issues/1474
- https://github.com/phishfort/phishfort-lists/issues/1473
- https://github.com/phishfort/phishfort-lists/issues/1472
- https://github.com/phishfort/phishfort-lists/issues/1471